### PR TITLE
fix: fixed browser-specific exports

### DIFF
--- a/packages/isomorphic-worker/package.json
+++ b/packages/isomorphic-worker/package.json
@@ -27,6 +27,10 @@
     "./package": "./package.json",
     "./package.json": "./package.json"
   },
+  "browser": {
+    "./worker-scope.js": "./dist/browser-worker-scope.js",
+    "./worker.js": "./dist/browser-worker.js"
+  },
   "files": [
     "dist",
     "src",


### PR DESCRIPTION
Added `browser` field to the package.json together with `exports` to support tooling that does not recognize `exports` field
This is needed for correct imports from this package in browser execution environments